### PR TITLE
fixed nova startup problems

### DIFF
--- a/rutracker.py
+++ b/rutracker.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """RuTracker search engine plugin for qBittorrent."""
-#VERSION: 2.19
+#VERSION: 2.20
 #AUTHORS: nbusseneau (https://github.com/nbusseneau/qBittorrent-RuTracker-plugin)
 
 class Config(object):


### PR DESCRIPTION
Made mirror checking much faster (~3 seconds for all)
No longer throwing an exception to nova on errors (it would disable the entire search engine)
Added the ability to recover from a failed startup login at a later search (with spam limit)
Disabled server spamming on client errors (such as username/password) (HTTP 4XX)